### PR TITLE
Fix Mixed Content violation with jQuery

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
       </section>
     </div>
     <script src="javascripts/scale.fix.js"></script>
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.1/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
     <script src="javascripts/functions.js"></script>
     
   </body>


### PR DESCRIPTION
The GitHub pages don't work right now with modern browsers because there is a Mixed Content violation. JavaScript files need to be loaded over HTTPS if the visiting page is also server with HTTPS, this should be resolved with this commit.
This commit also updates the jQuery library to the latest v1 version. All v1 versions should be compatible with each other.